### PR TITLE
Migrate to official statewave SDK

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -1,37 +1,18 @@
 from __future__ import annotations
 
-import asyncio
-
-import httpx
-
-
-class StatewaveError(Exception):
-    def __init__(self, message: str, status_code: int | None = None) -> None:
-        super().__init__(message)
-        self.status_code = status_code
+from statewave import AsyncStatewaveClient as _SDKAsyncStatewaveClient
+from statewave import StatewaveError
 
 
 class AsyncStatewaveClient:
+    """Thin app-level wrapper around the official Statewave SDK client.
+
+    Keeps the dict-based interface this app's callers (analyst.py, server.py)
+    already use, while delegating all HTTP/retry/polling to the SDK.
+    """
+
     def __init__(self, base_url: str, api_key: str | None = None) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._api_key = api_key
-        self._client = httpx.AsyncClient(timeout=30.0)
-
-    def _headers(self) -> dict[str, str]:
-        h = {"Content-Type": "application/json", "Accept": "application/json"}
-        if self._api_key:
-            h["X-API-Key"] = self._api_key
-        return h
-
-    def _raise_for_status(self, resp: httpx.Response) -> None:
-        if resp.is_success:
-            return
-        try:
-            body = resp.json()
-            msg = body.get("error", {}).get("message", resp.text)
-        except Exception:
-            msg = resp.text
-        raise StatewaveError(f"Statewave {resp.status_code}: {msg}", resp.status_code)
+        self._sdk = _SDKAsyncStatewaveClient(base_url, api_key=api_key)
 
     async def post_episode(
         self,
@@ -41,53 +22,27 @@ class AsyncStatewaveClient:
         payload: dict,
         metadata: dict | None = None,
     ) -> dict:
-        body: dict = {"subject_id": subject_id, "source": source, "type": type, "payload": payload}
-        if metadata:
-            body["metadata"] = metadata
-        resp = await self._client.post(f"{self._base_url}/v1/episodes", json=body, headers=self._headers())
-        self._raise_for_status(resp)
-        return resp.json()
-
-    async def compile_memories(self, subject_id: str, _poll_attempts: int = 10, _poll_interval: float = 0.3) -> dict:
-        resp = await self._client.post(
-            f"{self._base_url}/v1/memories/compile",
-            json={"subject_id": subject_id},
-            headers=self._headers(),
+        episode = await self._sdk.create_episode(
+            subject_id, source, type, payload, metadata=metadata
         )
-        self._raise_for_status(resp)
-        result = resp.json() if resp.status_code != 202 else {}
-        # 202 Accepted means compile is async server-side; poll timeline until
-        # memory count stabilises before the caller diffs the result.
-        if resp.status_code == 202:
-            prev_count = -1
-            for _ in range(_poll_attempts):
-                await asyncio.sleep(_poll_interval)
-                tl = await self.get_timeline(subject_id)
-                count = len(tl.get("memories", []))
-                if count == prev_count:
-                    break
-                prev_count = count
-        return result
+        return episode.model_dump(mode="json")
+
+    async def compile_memories(self, subject_id: str) -> dict:
+        job = await self._sdk.compile_memories_wait(subject_id)
+        return job.model_dump(mode="json")
 
     async def get_context(self, subject_id: str, task: str, max_tokens: int = 3000) -> dict:
-        resp = await self._client.post(
-            f"{self._base_url}/v1/context",
-            json={"subject_id": subject_id, "task": task, "max_tokens": max_tokens},
-            headers=self._headers(),
-        )
-        self._raise_for_status(resp)
-        return resp.json()
+        ctx = await self._sdk.get_context(subject_id, task, max_tokens=max_tokens)
+        return ctx.model_dump(mode="json")
 
     async def get_timeline(self, subject_id: str) -> dict:
-        resp = await self._client.get(
-            f"{self._base_url}/v1/timeline",
-            params={"subject_id": subject_id},
-            headers=self._headers(),
-        )
-        if resp.status_code == 404:
-            return {}
-        self._raise_for_status(resp)
-        return resp.json()
+        try:
+            timeline = await self._sdk.get_timeline(subject_id)
+        except StatewaveError as e:
+            if getattr(e, "status_code", None) == 404:
+                return {}
+            raise
+        return timeline.model_dump(mode="json")
 
     async def search_memories(self, subject_id: str) -> list[dict]:
         """Return all memories for a subject via the timeline endpoint."""
@@ -116,15 +71,11 @@ class AsyncStatewaveClient:
         return {"new": new, "superseded": superseded, "unchanged": unchanged}
 
     async def delete_subject(self, subject_id: str) -> dict:
-        resp = await self._client.delete(
-            f"{self._base_url}/v1/subjects/{subject_id}",
-            headers=self._headers(),
-        )
-        self._raise_for_status(resp)
-        return resp.json()
+        result = await self._sdk.delete_subject(subject_id)
+        return result.model_dump(mode="json")
 
     async def aclose(self) -> None:
-        await self._client.aclose()
+        await self._sdk.close()
 
     async def __aenter__(self) -> "AsyncStatewaveClient":
         return self

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httpx>=0.28.1
+statewave>=1.2.0
 litellm>=1.83.7
 python-dotenv>=1.2.2
 fastapi>=0.138.1

--- a/server.py
+++ b/server.py
@@ -14,7 +14,6 @@ import re
 from pathlib import Path
 from uuid import uuid4
 
-import httpx
 import litellm
 
 from dotenv import load_dotenv
@@ -23,6 +22,7 @@ from fastapi.security import APIKeyHeader
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from sse_starlette.sse import EventSourceResponse
+from statewave import StatewaveConnectionError
 
 from agents.analyst import run_analyst
 from agents.candidates import build_competitor_candidates
@@ -109,7 +109,7 @@ async def run_agents():
         try:
             await sw.delete_subject(SUBJECT_ID)
             await broadcast({"type": "status", "msg": "Reset: prior subject cleared"})
-        except (StatewaveError, httpx.RequestError):
+        except StatewaveError:
             await broadcast({"type": "status", "msg": "Starting fresh (no prior data)"})
 
     llm_key = os.environ.get("LLM_API_KEY", "")
@@ -164,7 +164,7 @@ async def run_agents():
         # will supersede it — the core conflict resolution demo moment.
         try:
             await _seed_bloomberg_stripe()
-        except httpx.RequestError as exc:
+        except StatewaveConnectionError as exc:
             await broadcast({
                 "type": "agent_log",
                 "agent": "bloomberg",


### PR DESCRIPTION
## Summary
- Replace hand-rolled httpx client in agents/base.py with the official statewave Python SDK
- Delete bespoke retry/polling logic (compile_memories_wait replaces manual timeline polling)
- Update requirements.txt: httpx -> statewave>=1.2.0

## Why
Per feedback: this repo hand-rolled a raw HTTP client instead of using the official SDK, causing drift from the API contract.

## Test plan
- [x] Modules import cleanly
- [x] server.py starts without errors
- [x] Manual run of the pipeline against a live Statewave instance
