### PR TITLE
docs: add npx one-liner as fastest way to start Statewave

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Three analyst agents ingest conflicting source documents concurrently. Watch Sta
   - [Architecture](#architecture)
   - [Prerequisites](#prerequisites)
   - [Setup and run locally](#setup-and-run-locally)
-    - [Option A: Docker Compose (recommended)](#option-a-docker-compose-recommended)
-    - [Option B: run Python directly](#option-b-run-python-directly)
+    - [Option A: npx (fastest)](#option-a-npx-fastest)
+    - [Option B: Docker Compose](#option-b-docker-compose)
+    - [Option C: run Python directly](#option-c-run-python-directly)
   - [Usage](#usage)
   - [Source documents](#source-documents)
   - [Environment variables](#environment-variables)
@@ -105,18 +106,61 @@ Demo interface during a full multi-agent run:
 
 ## Prerequisites
 
-- **Docker** and **Docker Compose**: required for Option A (recommended)
+- **Node.js 20+**: required for Option A (fastest — boots Statewave via `npx`) and for the audit inspector
+- **Python 3.11+**: required to run this demo app in all options
 - **LLM API key** from your Groq account (default) or any provider supported by LiteLLM (set `LLM_MODEL` accordingly)
-- **Python 3.11+**: only needed for Option B (run without Docker)
-- **Node.js 20+**: optional, for the audit inspector only
+- **Docker** and **Docker Compose**: only needed for Option B
 
 ---
 
 ## Setup and run locally
 
-### Option A: Docker Compose (recommended)
+### Option A: npx (fastest)
 
-One command brings up the Statewave backend, its database, and the demo app together.
+Statewave ships a one-line launcher — no Docker, no account, runs offline. It boots the API, admin console, and Postgres, and wires itself into your MCP clients.
+
+**1. Clone this repo**
+
+```bash
+git clone https://github.com/smaramwbc/statewave-multi-agent-memory
+cd statewave-multi-agent-memory
+```
+
+**2. Start Statewave**
+
+```bash
+npx @statewavedev/statewave
+```
+
+This starts the Statewave backend at `http://localhost:8100` (leave this running in its own terminal). macOS/Linux/Windows all work; you can also use the install script instead of `npx`:
+
+```bash
+curl -fsSL https://www.statewave.ai/install | sh   # macOS/Linux
+irm https://www.statewave.ai/install.ps1 | iex       # Windows PowerShell
+```
+
+**3. Install Python dependencies and configure environment**
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Open `.env` and set `LLM_API_KEY` to your LLM provider API key.
+
+**4. Start this demo**
+
+```bash
+python server.py
+```
+
+Open [http://localhost:8000](http://localhost:8000) and click **Run pipeline**.
+
+---
+
+### Option B: Docker Compose
+
+Use this if you want Statewave running alongside the demo in containers (e.g. for a production-like Postgres setup), rather than the lightweight `npx` launcher.
 
 **1. Clone this repo**
 
@@ -143,7 +187,7 @@ Open [http://localhost:8000](http://localhost:8000) and click **Run pipeline**.
 
 ---
 
-### Option B: run Python directly
+### Option C: run Python directly
 
 Use this if you prefer to run the demo server outside Docker while still running Statewave via Docker.
 


### PR DESCRIPTION
## Summary
- Adds the `npx @statewavedev/statewave` one-liner (plus the `curl`/`irm` install-script alternatives) as **Option A: npx (fastest)** for starting the Statewave backend — no Docker, no account, runs offline.
- Keeps Docker Compose as **Option B**, for anyone who wants Statewave running in containers alongside a production-like Postgres setup.
- Renumbers the former Docker-only "Option B: run Python directly" to **Option C**, unchanged in content.
- Reorders **Prerequisites** so Node.js/npx is listed as the fastest path, Python is required in all options, and Docker is scoped to Option B only.

## Why
statewave.ai and the main [smaramwbc/statewave](https://github.com/smaramwbc/statewave) repo both lead with `npx @statewavedev/statewave` as the recommended, lowest-friction way to boot Statewave locally. This demo repo's README only documented Docker Compose, requiring Docker as a hard prerequisite even in the "run Python directly" path. That's a mismatch with how the parent project wants new users to get started, and an unnecessary barrier for anyone who just wants to try the demo without installing Docker.

## Test plan
- [x] Verified TOC anchors match the new heading text/order
- [x] Verified npx command and install-script URLs against statewave.ai and the statewave repo
- [x] Manual run: `npx @statewavedev/statewave` → `python server.py` → confirm pipeline runs end-to-end against the npx-launched backend