### PR TITLE
Feat/configurable domain tools tests docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Statewave server URL (default if running locally via Docker)
+# Statewave server URL (default if running locally via npx or Docker)
 STATEWAVE_URL=http://localhost:8100
 
 # Optional: Statewave API key (if your instance requires auth)
@@ -13,6 +13,24 @@ LLM_API_KEY=your-llm-api-key-here
 #   anthropic/claude-3-5-haiku-20241022  (requires an Anthropic key)
 #   ollama/llama3          (local Ollama instance)
 # LLM_MODEL=groq/llama-3.3-70b-versatile
+
+# ── Adapting to your domain ────────────────────────────────────────────────────
+
+# Shared Statewave memory namespace for this pipeline. Change to something
+# meaningful for your domain (e.g. "healthcare-news", "saas-competitors").
+# SUBJECT_ID=market-intel
+
+# Synthesis system prompt — the instruction given to the LLM when answering
+# questions in the chat panel. Override to match your domain, e.g.:
+#   "You are a healthcare researcher. Answer using ONLY the provided context..."
+# SYNTHESIS_SYSTEM_PROMPT=You are a market intelligence analyst...
+
+# Demo seeding: pre-seeds a stale Bloomberg Stripe fact before agents run to
+# guarantee the TechCrunch→Bloomberg supersession. Set to false when using
+# your own source files so agents start with a clean subject.
+# DEMO_SEED_BLOOMBERG_STRIPE=true
+
+# ── Security ───────────────────────────────────────────────────────────────────
 
 # Optional: secret key required in X-API-Key header for all API endpoints.
 # Leave unset to disable auth (local dev only). Set to a random string for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Syntax check all Python files
         run: find . -name "*.py" -not -path "./.venv/*" -exec python -m py_compile {} +
 
+      - name: Run unit tests
+        run: pytest tests/ -v
+
       - name: Check links in markdown
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ Three analyst agents ingest conflicting source documents concurrently. Watch Sta
   - [Architecture](#architecture)
   - [Prerequisites](#prerequisites)
   - [Setup and run locally](#setup-and-run-locally)
-    - [Option A: Docker Compose (recommended)](#option-a-docker-compose-recommended)
-    - [Option B: run Python directly](#option-b-run-python-directly)
+    - [Option A: npx (fastest)](#option-a-npx-fastest)
+    - [Option B: Docker Compose](#option-b-docker-compose)
+    - [Option C: run Python directly](#option-c-run-python-directly)
   - [Usage](#usage)
   - [Source documents](#source-documents)
   - [Environment variables](#environment-variables)
   - [Statewave API endpoints used](#statewave-api-endpoints-used)
   - [Audit inspector](#audit-inspector)
+    - [Reading the audit trail](#reading-the-audit-trail)
+  - [Adapting to your domain](#adapting-to-your-domain)
+  - [Using Statewave with multi-agent frameworks](#using-statewave-with-multi-agent-frameworks)
   - [Developer reference](#developer-reference)
     - [Project structure](#project-structure)
     - [SSE event types](#sse-event-types)
@@ -105,18 +109,61 @@ Demo interface during a full multi-agent run:
 
 ## Prerequisites
 
-- **Docker** and **Docker Compose**: required for Option A (recommended)
+- **Node.js 20+**: required for Option A (fastest; boots Statewave via `npx`) and for the audit inspector
+- **Python 3.11+**: required to run this demo app in all options
 - **LLM API key** from your Groq account (default) or any provider supported by LiteLLM (set `LLM_MODEL` accordingly)
-- **Python 3.11+**: only needed for Option B (run without Docker)
-- **Node.js 20+**: optional, for the audit inspector only
+- **Docker** and **Docker Compose**: only needed for Option B
 
 ---
 
 ## Setup and run locally
 
-### Option A: Docker Compose (recommended)
+### Option A: npx (fastest)
 
-One command brings up the Statewave backend, its database, and the demo app together.
+Statewave ships a one-line launcher: no Docker, no account, runs offline. It boots the API, admin console, and Postgres, and wires itself into your MCP clients.
+
+**1. Clone this repo**
+
+```bash
+git clone https://github.com/smaramwbc/statewave-multi-agent-memory
+cd statewave-multi-agent-memory
+```
+
+**2. Start Statewave**
+
+```bash
+npx @statewavedev/statewave
+```
+
+This starts the Statewave backend at `http://localhost:8100` (leave this running in its own terminal). macOS/Linux/Windows all work; you can also use the install script instead of `npx`:
+
+```bash
+curl -fsSL https://www.statewave.ai/install | sh   # macOS/Linux
+irm https://www.statewave.ai/install.ps1 | iex       # Windows PowerShell
+```
+
+**3. Install Python dependencies and configure environment**
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Open `.env` and set `LLM_API_KEY` to your LLM provider API key.
+
+**4. Start this demo**
+
+```bash
+python server.py
+```
+
+Open [http://localhost:8000](http://localhost:8000) and click **Run pipeline**.
+
+---
+
+### Option B: Docker Compose
+
+Use this if you want Statewave running alongside the demo in containers (e.g. for a production-like Postgres setup), rather than the lightweight `npx` launcher.
 
 **1. Clone this repo**
 
@@ -143,7 +190,7 @@ Open [http://localhost:8000](http://localhost:8000) and click **Run pipeline**.
 
 ---
 
-### Option B: run Python directly
+### Option C: run Python directly
 
 Use this if you prefer to run the demo server outside Docker while still running Statewave via Docker.
 
@@ -208,13 +255,16 @@ The Bloomberg document intentionally contains a pre-reversal figure. The conflic
 
 ## Environment variables
 
-| Variable            | Required | Default                 | Description                                                                               |
-| ------------------- | -------- | ----------------------- | ----------------------------------------------------------------------------------------- |
-| `LLM_API_KEY`       | Yes      | —                       | API key for your LLM provider                                                             |
-| `LLM_MODEL`         | No       | `groq/llama-3.3-70b-versatile` | LiteLLM model string — change to use a different provider (e.g. `openai/gpt-4o`) |
-| `STATEWAVE_URL`     | No       | `http://localhost:8100` | Statewave server base URL                                                                 |
-| `STATEWAVE_API_KEY` | No       | —                       | API key if your Statewave instance has auth enabled                                       |
-| `APP_SECRET`        | No       | —                       | When set, all demo API endpoints require `X-API-Key: <value>`. Leave unset for local dev. |
+| Variable                    | Required | Default                        | Description                                                                                       |
+| --------------------------- | -------- | ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `LLM_API_KEY`               | Yes      | (none)                         | API key for your LLM provider                                                                     |
+| `LLM_MODEL`                 | No       | `groq/llama-3.3-70b-versatile` | LiteLLM model string. Change to use a different provider, e.g. `openai/gpt-4o`                   |
+| `STATEWAVE_URL`             | No       | `http://localhost:8100`        | Statewave server base URL                                                                         |
+| `STATEWAVE_API_KEY`         | No       | (none)                         | API key if your Statewave instance has auth enabled                                               |
+| `APP_SECRET`                | No       | (none)                         | When set, all demo API endpoints require `X-API-Key: <value>`. Leave unset for local dev.        |
+| `SUBJECT_ID`                | No       | `market-intel`                 | Shared Statewave memory namespace. Change when adapting to a different domain.                    |
+| `SYNTHESIS_SYSTEM_PROMPT`   | No       | (built-in analyst prompt)      | System instruction given to the LLM when answering questions. Override to match your domain.      |
+| `DEMO_SEED_BLOOMBERG_STRIPE`| No       | `true`                         | Pre-seeds the stale Bloomberg Stripe fact. Set to `false` when using your own source files.       |
 
 ---
 
@@ -240,6 +290,99 @@ npm install
 npx tsx src/index.ts --subject-id market-intel
 ```
 
+### Reading the audit trail
+
+The inspector output has three sections:
+
+**Episodes**: raw, append-only inputs from each agent. Each episode shows the source, type, and the payload text that was ingested.
+
+**Memories**: the compiled, typed facts extracted from episodes. Each memory shows:
+- `status: active`: currently the authoritative version of this fact
+- `status: superseded`: an older version that was replaced; still in the audit trail for provenance
+- `superseded_by`: the ID of the memory that replaced it
+
+**Supersessions**: the conflict resolution decisions. Each entry shows:
+- Which memory was replaced and by which
+- The Jaccard word-overlap similarity score that triggered the supersession (threshold: ≥ 0.6)
+- The source episodes on both sides
+
+Example output after the demo run:
+
+```
+EPISODES (5 total)
+  bloomberg/2026-05-16  agent.analyst.findings  Stripe pricing (bloomberg, 2026-05-16): 3.5% + 35¢...
+  techcrunch/2026-06-01 agent.analyst.findings  Stripe pricing (techcrunch, 2026-06-01): 2.9% + 30¢...
+  earnings/2026-06-15   agent.analyst.findings  Stripe pricing (earnings, 2026-06-15): 2.9% + 30¢...
+  bloomberg/2026-05-16  agent.analyst.findings  Square positioning (bloomberg): leading mobile POS...
+  earnings/2026-06-15   agent.analyst.findings  Square revenue miss Q2 2026...
+
+MEMORIES (4 active, 1 superseded)
+  [active]     techcrunch  Stripe pricing (techcrunch, 2026-06-01): 2.9% + 30¢...
+  [superseded] bloomberg   Stripe pricing (bloomberg, 2026-05-16): 3.5% + 35¢...
+                             superseded_by → techcrunch memory (Jaccard: 0.72)
+  [active]     bloomberg   Square positioning (bloomberg): leading mobile POS...
+  [active]     earnings    Square: missed Q2 revenue estimates by 8%...
+  [active]     bloomberg   Square key differentiators: offline mode, hardware...
+
+SUPERSESSIONS (1)
+  bloomberg Stripe pricing → superseded by techcrunch Stripe pricing
+  similarity: 0.72  (threshold: 0.60)
+  older episode: bloomberg/2026-05-16
+  newer episode: techcrunch/2026-06-01
+```
+
+The key insight: Bloomberg's independent Square facts (`positioning`, `differentiators`) survived the Stripe supersession because they are separate atomic memories with no word overlap against the Stripe memories. Only the stale pricing fact was replaced.
+
+---
+
+## Adapting to your domain
+
+The demo is wired for competitive intelligence on payment processors. To run it for a different domain, you only need to change `.env` and drop in new JSON source files. No Python changes required.
+
+**1. Set your subject ID and prompts in `.env`**
+
+```bash
+# The shared memory namespace for this pipeline run
+SUBJECT_ID=healthcare-news
+
+# The instruction given to the LLM when answering questions in the chat panel
+SYNTHESIS_SYSTEM_PROMPT=You are a healthcare policy analyst. Answer using ONLY the provided memory context. Do not invent facts. Be concise: 3-5 sentences.
+
+# Disable the payment-processor seed (only relevant for the default demo sources)
+DEMO_SEED_BLOOMBERG_STRIPE=false
+```
+
+**2. Add your source files to `sources/`**
+
+Each JSON file becomes one agent. The agent ID is the filename stem (e.g. `reuters.json` → agent `reuters`). Source files follow this schema:
+
+```json
+{
+  "source": "reuters",
+  "published": "2024-11-01",
+  "headline": "Optional headline for context",
+  "competitors": [
+    {
+      "name": "Entity Name",
+      "pricing_model": "Relevant factual claim about pricing or cost",
+      "market_positioning": "How this entity positions itself",
+      "key_differentiators": ["differentiator one", "differentiator two"],
+      "confidence_notes": "Source and date of this data"
+    }
+  ]
+}
+```
+
+The field names (`pricing_model`, `market_positioning`, `key_differentiators`) are generic; they map to "primary fact", "positioning fact", and "list of facts" in Statewave. Name them whatever fits your domain. Only `name` is required.
+
+**3. Run**
+
+```bash
+python server.py
+```
+
+All JSON files in `sources/` are discovered automatically. The pipeline runs one agent per file. Conflict detection works the same way regardless of domain.
+
 ---
 
 ## Developer reference
@@ -249,17 +392,22 @@ npx tsx src/index.ts --subject-id market-intel
 ```
 statewave-multi-agent-memory/
 ├── agents/
-│   ├── analyst.py          # Agent logic: ingest → compile → diff
-│   └── base.py             # AsyncStatewaveClient wrapper
+│   ├── analyst.py          # Agent logic: ingest, compile, diff
+│   ├── base.py             # AsyncStatewaveClient wrapper
+│   └── candidates.py       # Deterministic structured memory candidate builder
 ├── sources/
-│   ├── bloomberg.json      # Stale Stripe pricing (3.5%) — to be superseded
-│   ├── techcrunch.json     # Corrected Stripe pricing (2.9%) — supersedes Bloomberg
+│   ├── bloomberg.json      # Stale Stripe pricing (3.5%) to be superseded
+│   ├── techcrunch.json     # Corrected Stripe pricing (2.9%) supersedes Bloomberg
 │   └── earnings.json       # Corroborates TechCrunch, adds Square data
+├── tests/
+│   ├── test_candidates.py  # Unit tests for build_competitor_candidates
+│   └── test_memory_diff.py # Unit tests for the memory diff logic
 ├── inspector/
 │   └── src/index.ts        # Audit trail: episodes, memories, supersessions
 ├── static/
 │   └── index.html          # Browser UI (SSE-driven, zero build step)
 ├── server.py               # FastAPI app: /run /ask /events /memories
+├── statewave_tools.py      # Drop-in helpers: remember(), compile(), recall()
 ├── Dockerfile              # Builds the demo server as a container image
 ├── docker-compose.yml      # Starts db + Statewave API + demo in one command
 ├── requirements.txt
@@ -276,7 +424,139 @@ The browser receives a single `/events` stream. Event types:
 | `memory_update`   | `{ agent, diff }`   | Applies a DOM diff to the Memory panel        |
 | `agents_done`     | `{ supersessions }` | Enables chat input; updates status bar count  |
 | `synthesis_token` | `{ token }`         | Streams one token into the active chat bubble |
-| `synthesis_done`  | —                   | Finalizes the chat bubble                     |
+| `synthesis_done`  | (none)              | Finalizes the chat bubble                     |
+
+---
+
+## Using Statewave with multi-agent frameworks
+
+Most developers building multi-agent systems reach for a framework like CrewAI, LangGraph, or the Claude SDK rather than writing raw orchestration. Statewave slots in as the **shared memory layer** for any of them. The three API calls (`/v1/episodes`, `/v1/memories/compile`, `/v1/context`) are framework-agnostic; you wrap them in a tool, a node, or a hook.
+
+### The pattern (framework-independent)
+
+Copy [`statewave_tools.py`](statewave_tools.py) from this repo into your project. It wraps the official Statewave SDK in three simple functions (`pip install statewave`):
+
+```python
+from statewave_tools import configure, remember, compile, recall
+
+configure("http://localhost:8100")   # point at your Statewave instance
+
+# 1. Ingest: write what your agent found
+remember("my-subject", "agent-a", "Stripe charges 2.9% + 30¢ per transaction.")
+
+# 2. Compile: detect conflicts and supersede stale facts
+compile("my-subject")
+
+# 3. Use: get ranked, conflict-resolved context for the next prompt
+context = recall("my-subject", "What does Stripe charge?")
+# → drop context directly into your LLM system prompt or user message
+```
+
+These three functions are all you need regardless of which framework you use.
+
+### CrewAI
+
+```python
+from crewai.tools import tool
+from statewave_tools import configure, remember, compile, recall
+
+configure("http://localhost:8100")
+
+@tool("Remember a finding")
+def remember_finding(subject_id: str, source: str, text: str) -> str:
+    """Commit a finding to shared memory and compile it."""
+    remember(subject_id, source, text)
+    compile(subject_id)
+    return "committed"
+
+@tool("Recall context")
+def recall_context(subject_id: str, question: str) -> str:
+    """Retrieve conflict-resolved memory context for a question."""
+    return recall(subject_id, question)
+```
+
+Assign both tools to whichever agents need shared memory. Statewave handles conflict resolution when two agents write contradicting facts; you write no merge logic in the crew.
+
+### LangGraph
+
+```python
+from langgraph.graph import StateGraph, MessagesState
+from statewave_tools import configure, remember, compile, recall
+
+configure("http://localhost:8100")
+SUBJECT = "research-subject"
+
+def ingest_node(state: MessagesState):
+    finding = state["messages"][-1].content
+    remember(SUBJECT, "researcher", finding)
+    compile(SUBJECT)
+    return state
+
+def recall_node(state: MessagesState):
+    question = state["messages"][-1].content
+    context = recall(SUBJECT, question)
+    return {"messages": [{"role": "system", "content": context}] + state["messages"]}
+
+graph = StateGraph(MessagesState)
+graph.add_node("ingest", ingest_node)
+graph.add_node("recall", recall_node)
+```
+
+### Claude (Anthropic SDK / tool use)
+
+```python
+import anthropic
+from statewave_tools import configure, remember, compile, recall
+
+configure("http://localhost:8100")
+client = anthropic.Anthropic()
+
+tools = [
+    {
+        "name": "remember",
+        "description": "Commit a finding to shared memory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "subject_id": {"type": "string"},
+                "text": {"type": "string"}
+            },
+            "required": ["subject_id", "text"]
+        }
+    },
+    {
+        "name": "recall",
+        "description": "Retrieve conflict-resolved context for a question.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "subject_id": {"type": "string"},
+                "question": {"type": "string"}
+            },
+            "required": ["subject_id", "question"]
+        }
+    }
+]
+
+def handle_tool(name, inputs):
+    if name == "remember":
+        remember(inputs["subject_id"], "claude-agent", inputs["text"])
+        compile(inputs["subject_id"])
+        return "committed"
+    if name == "recall":
+        return recall(inputs["subject_id"], inputs["question"])
+```
+
+Multiple Claude agents sharing the same `subject_id` automatically get conflict-resolved memory. This is the same mechanism the demo uses, exposed as native tool calls.
+
+### What you never have to write
+
+Whichever framework you use, Statewave removes the same set of problems:
+
+- **Conflict detection**: no custom similarity checks or "latest wins" rules
+- **Supersession with provenance**: full audit trail of which episode beat which, and why
+- **Token management**: `max_tokens` on `/v1/context` returns a ranked bundle that fits your prompt budget
+- **Concurrent write safety**: episodes are append-only; compile is idempotent
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv>=1.2.2
 fastapi>=0.139.0
 uvicorn>=0.50.0
 sse-starlette>=3.4.5
+pytest>=8.0.0

--- a/server.py
+++ b/server.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
+from contextlib import asynccontextmanager
 from pathlib import Path
 from uuid import uuid4
 
@@ -30,8 +32,45 @@ from agents.base import AsyncStatewaveClient, StatewaveError
 
 load_dotenv()
 
-SUBJECT_ID = "market-intel"
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+SUBJECT_ID = os.environ.get("SUBJECT_ID", "market-intel")
 SOURCES_DIR = Path(__file__).parent / "sources"
+
+_DEFAULT_SYNTHESIS_PROMPT = (
+    "You are a market intelligence analyst. Answer using ONLY the provided "
+    "memory context — facts compiled and conflict-resolved by Statewave. "
+    "Do not invent facts. Cite which source (bloomberg, techcrunch, earnings) "
+    "each claim comes from when known. Be concise: 3-5 sentences."
+)
+_SYNTHESIS_PROMPT = os.environ.get("SYNTHESIS_SYSTEM_PROMPT", _DEFAULT_SYNTHESIS_PROMPT)
+_DEMO_SEED = os.environ.get("DEMO_SEED_BLOOMBERG_STRIPE", "true").lower() == "true"
+
+
+def _discover_agents(sources_dir: Path) -> list[tuple[str, str]]:
+    """Return [(agent_id, filename)] for every JSON file in sources_dir, sorted."""
+    return [(p.stem, p.name) for p in sorted(sources_dir.glob("*.json"))]
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    llm_key = os.environ.get("LLM_API_KEY", "")
+    if not llm_key:
+        raise RuntimeError(
+            "LLM_API_KEY is not set. Copy .env.example to .env and add your API key."
+        )
+    sw_url = os.environ.get("STATEWAVE_URL", "http://localhost:8100")
+    sw_key = os.environ.get("STATEWAVE_API_KEY")
+    try:
+        # Lightweight reachability probe: get_timeline returns {} on a 404
+        # (server up), and raises StatewaveConnectionError only when the
+        # backend can't be reached.
+        async with AsyncStatewaveClient(sw_url, sw_key) as sw:
+            await sw.get_timeline("healthcheck")
+    except StatewaveConnectionError:
+        logger.warning("Statewave not reachable at %s — start it before running agents.", sw_url)
+    yield
 
 _APP_SECRET = os.environ.get("APP_SECRET", "")
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
@@ -43,16 +82,10 @@ async def _require_auth(key: str | None = Security(_api_key_header)) -> None:
     if key != _APP_SECRET:
         raise HTTPException(status_code=401, detail="Invalid or missing X-API-Key")
 
-_AGENTS = [
-    ("bloomberg",  "bloomberg.json"),
-    ("techcrunch", "techcrunch.json"),
-    ("earnings",   "earnings.json"),
-]
-
 # Per-connection SSE queues: session_id -> asyncio.Queue
 _queues: dict[str, asyncio.Queue] = {}
 
-app = FastAPI(title="Statewave Multi-Agent Demo")
+app = FastAPI(title="Statewave Multi-Agent Demo", lifespan=lifespan)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
@@ -104,7 +137,7 @@ async def events():
 
 @app.post("/run", dependencies=[Security(_require_auth)])
 async def run_agents():
-    """Reset Statewave subject and launch all 3 analyst agents."""
+    """Reset Statewave subject and launch analyst agents for each source file."""
     async with _sw() as sw:
         try:
             await sw.delete_subject(SUBJECT_ID)
@@ -112,6 +145,7 @@ async def run_agents():
         except StatewaveError:
             await broadcast({"type": "status", "msg": "Starting fresh (no prior data)"})
 
+    agents = _discover_agents(SOURCES_DIR)
     llm_key = os.environ.get("LLM_API_KEY", "")
     llm_model = os.environ.get("LLM_MODEL", "groq/llama-3.3-70b-versatile")
     sw_url = os.environ.get("STATEWAVE_URL", "http://localhost:8100")
@@ -159,82 +193,62 @@ async def run_agents():
     async def _run():
         await broadcast({"type": "run_started"})
 
-        # Seed Bloomberg's stale Stripe fact directly (no LLM) so it's compiled
-        # and active before any agent runs. This guarantees TechCrunch's 2.9% fact
-        # will supersede it — the core conflict resolution demo moment.
-        try:
-            await _seed_bloomberg_stripe()
-        except StatewaveConnectionError as exc:
+        # Demo mode: pre-seed Bloomberg's stale Stripe pricing so TechCrunch's
+        # 2.9% fact will supersede it — the core conflict resolution demo moment.
+        # Disable by setting DEMO_SEED_BLOOMBERG_STRIPE=false in .env when using
+        # your own source files.
+        if _DEMO_SEED and (SOURCES_DIR / "bloomberg.json").exists():
+            try:
+                await _seed_bloomberg_stripe()
+            except StatewaveConnectionError as exc:
+                await broadcast({
+                    "type": "agent_log",
+                    "agent": "bloomberg",
+                    "msg": (
+                        "ERROR: unable to reach the Statewave backend at "
+                        f"{sw_url}. Start the Statewave service or set STATEWAVE_URL. "
+                        f"Details: {exc}"
+                    ),
+                })
+                await broadcast({"type": "agents_done", "supersessions": 0})
+                return
             await broadcast({
-                "type": "agent_log",
-                "agent": "bloomberg",
-                "msg": (
-                    "ERROR: unable to reach the Statewave backend at "
-                    f"{sw_url}. Start the Statewave service or set STATEWAVE_URL. "
-                    f"Details: {exc}"
-                ),
+                "type": "agent_log", "agent": "bloomberg",
+                "msg": "Seeded: Stripe pricing at 3.5% + 35¢ (stale Bloomberg fact, pre-reversal)",
             })
-            await broadcast({"type": "agents_done", "supersessions": 0})
-            return
-        await broadcast({
-            "type": "agent_log", "agent": "bloomberg",
-            "msg": "Seeded: Stripe pricing at 3.5% + 35¢ (stale Bloomberg fact, pre-reversal)",
-        })
-        await broadcast({
-            "type": "agent_log", "agent": "bloomberg",
-            "msg": "Waiting for TechCrunch and Earnings agents to commit contradicting facts...",
-        })
+            await broadcast({
+                "type": "agent_log", "agent": "bloomberg",
+                "msg": "Waiting for TechCrunch and Earnings agents to commit contradicting facts...",
+            })
 
         # One shared lock serializes each agent's post→compile→diff so concurrent
         # agents never double-compile the same uncompiled episode.
         compile_lock = asyncio.Lock()
 
-        # All 3 agents run concurrently — no stagger needed since seed is already committed.
-        # Bloomberg skips Stripe: that fact was already seeded above, so re-extracting it
-        # from bloomberg.json would create a bloomberg→bloomberg supersession and make the
-        # "1 conflict resolved" count non-deterministic.
-        bloomberg_task = asyncio.create_task(run_analyst(
-            agent_id="bloomberg",
-            source_file=str(SOURCES_DIR / "bloomberg.json"),
-            subject_id=SUBJECT_ID,
-            llm_api_key=llm_key,
-            llm_model=llm_model,
-            statewave_url=sw_url,
-            statewave_api_key=sw_key,
-            on_log=on_log,
-            on_memory_update=on_memory_update,
-            skip_competitors={"Stripe"},
-            compile_lock=compile_lock,
-        ))
-        tc_task = asyncio.create_task(run_analyst(
-            agent_id="techcrunch",
-            source_file=str(SOURCES_DIR / "techcrunch.json"),
-            subject_id=SUBJECT_ID,
-            llm_api_key=llm_key,
-            llm_model=llm_model,
-            statewave_url=sw_url,
-            statewave_api_key=sw_key,
-            on_log=on_log,
-            on_memory_update=on_memory_update,
-            compile_lock=compile_lock,
-        ))
-        ea_task = asyncio.create_task(run_analyst(
-            agent_id="earnings",
-            source_file=str(SOURCES_DIR / "earnings.json"),
-            subject_id=SUBJECT_ID,
-            llm_api_key=llm_key,
-            llm_model=llm_model,
-            statewave_url=sw_url,
-            statewave_api_key=sw_key,
-            on_log=on_log,
-            on_memory_update=on_memory_update,
-            compile_lock=compile_lock,
-        ))
-        results = await asyncio.gather(bloomberg_task, tc_task, ea_task, return_exceptions=True)
+        # Bloomberg skips Stripe only in demo mode (fact already seeded above).
+        # All other agents run without skipping.
+        tasks = []
+        for agent_id, source_filename in agents:
+            skip = {"Stripe"} if (_DEMO_SEED and agent_id == "bloomberg") else None
+            tasks.append(asyncio.create_task(run_analyst(
+                agent_id=agent_id,
+                source_file=str(SOURCES_DIR / source_filename),
+                subject_id=SUBJECT_ID,
+                llm_api_key=llm_key,
+                llm_model=llm_model,
+                statewave_url=sw_url,
+                statewave_api_key=sw_key,
+                on_log=on_log,
+                on_memory_update=on_memory_update,
+                skip_competitors=skip,
+                compile_lock=compile_lock,
+            )))
+        results = await asyncio.gather(*tasks, return_exceptions=True)
 
         total_supersessions = 0
-        for (agent_id, _), result in zip(_AGENTS, results):
+        for (agent_id, _), result in zip(agents, results):
             if isinstance(result, Exception):
+                logger.error("Agent %s failed: %s", agent_id, result)
                 await broadcast({"type": "agent_log", "agent": agent_id,
                                  "msg": f"ERROR: {result}"})
             elif isinstance(result, dict):
@@ -281,15 +295,7 @@ async def ask(body: dict):
             model=llm_model,
             api_key=llm_key,
             messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "You are a market intelligence analyst. Answer using ONLY the provided "
-                        "memory context — facts compiled and conflict-resolved by Statewave. "
-                        "Do not invent facts. Cite which source (bloomberg, techcrunch, earnings) "
-                        "each claim comes from when known. Be concise: 3-5 sentences."
-                    ),
-                },
+                {"role": "system", "content": _SYNTHESIS_PROMPT},
                 {
                     "role": "user",
                     "content": (
@@ -303,11 +309,15 @@ async def ask(body: dict):
             timeout=60.0,
         )
         async for chunk in stream:
-            token = chunk.choices[0].delta.content
-            if token:
-                await broadcast({"type": "synthesis_token", "token": token})
+            content = chunk.choices[0].delta.content
+            if content:
+                await broadcast({"type": "synthesis_token", "token": content})
         await broadcast({"type": "synthesis_done"})
+    except (litellm.APIError, litellm.AuthenticationError, litellm.RateLimitError) as e:
+        logger.error("LLM error during synthesis: %s", e)
+        await broadcast({"type": "synthesis_error", "msg": str(e)})
     except Exception as e:
+        logger.error("Unexpected synthesis error: %s", e)
         await broadcast({"type": "synthesis_error", "msg": str(e)})
 
     return {"status": "ok"}

--- a/statewave_tools.py
+++ b/statewave_tools.py
@@ -1,0 +1,99 @@
+"""
+statewave_tools.py — Drop this file into any project to add Statewave memory.
+
+Three functions cover the full loop:
+  remember()  — commit a finding to shared memory
+  compile()   — detect conflicts and supersede stale facts
+  recall()    — retrieve ranked, conflict-resolved context for a prompt
+
+Works standalone; no other files from this repo are required.
+Requires: statewave  (pip install statewave)
+
+Quick start:
+    from statewave_tools import configure, remember, compile, recall
+
+    configure("http://localhost:8100")          # point at your Statewave instance
+    remember("my-subject", "agent-a", "Stripe charges 2.9% + 30¢ per card transaction.")
+    compile("my-subject")
+    context = recall("my-subject", "What does Stripe charge?")
+    # → pass context directly into your LLM prompt
+"""
+from __future__ import annotations
+
+from statewave import StatewaveClient
+
+_SW_URL: str = "http://localhost:8100"
+_SW_KEY: str | None = None
+
+
+def configure(url: str, api_key: str | None = None) -> None:
+    """Set the Statewave server URL and optional API key for all subsequent calls."""
+    global _SW_URL, _SW_KEY
+    _SW_URL = url.rstrip("/")
+    _SW_KEY = api_key
+
+
+def _client() -> StatewaveClient:
+    return StatewaveClient(_SW_URL, api_key=_SW_KEY)
+
+
+def remember(
+    subject_id: str,
+    source: str,
+    text: str,
+    event_type: str = "agent.findings",
+) -> dict:
+    """Commit a finding as a raw episode to the shared Statewave subject.
+
+    Call compile() after ingesting to make it retrievable via recall().
+
+    Args:
+        subject_id: The shared namespace (e.g. "market-intel", "my-project").
+        source:     Which agent or system produced this finding (e.g. "agent-a").
+        text:       The finding in natural language.
+        event_type: Episode type label (default "agent.findings").
+
+    Returns:
+        The episode object returned by Statewave.
+    """
+    with _client() as sw:
+        episode = sw.create_episode(subject_id, source, event_type, {"text": text})
+    return episode.model_dump(mode="json")
+
+
+def compile(subject_id: str) -> dict:
+    """Run Statewave's conflict detector against all uncompiled episodes.
+
+    Memories that exceed the Jaccard similarity threshold are automatically
+    superseded — the older one is marked stale with a provenance link.
+    This is idempotent; calling it multiple times is safe. It waits for the
+    compile to finish so the results are retrievable via recall() right away.
+
+    Args:
+        subject_id: The shared namespace to compile.
+
+    Returns:
+        The compile result object from Statewave.
+    """
+    with _client() as sw:
+        result = sw.compile_memories_wait(subject_id)
+    return result.model_dump(mode="json")
+
+
+def recall(subject_id: str, question: str, max_tokens: int = 2000) -> str:
+    """Retrieve ranked, conflict-resolved context ready to drop into a prompt.
+
+    Only active (non-superseded) memories are returned. The result is
+    token-bounded to max_tokens and ranked by relevance to question.
+
+    Args:
+        subject_id: The shared namespace to query.
+        question:   The task or question driving the context retrieval.
+        max_tokens: Maximum tokens in the returned context bundle.
+
+    Returns:
+        assembled_context string — pass this directly to your LLM.
+    """
+    with _client() as sw:
+        ctx = sw.get_context(subject_id, question, max_tokens=max_tokens)
+    return ctx.assembled_context

--- a/static/index.html
+++ b/static/index.html
@@ -376,15 +376,28 @@
   let totalConflicts = 0;
 
   // ── SSE connection ─────────────────────────────────────────────────────────
-  const es = new EventSource('/events');
+  let es;
+  let _reconnectTimer = null;
 
-  es.onopen = () => setStatus('Connected — click Run Agents to start');
-  es.onerror = () => setStatus('SSE connection lost — refresh page');
+  function connectSSE() {
+    if (es) { try { es.close(); } catch (_) {} }
+    es = new EventSource('/events');
+    es.onopen = () => {
+      if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+      setStatus('Connected — click Run Agents to start');
+    };
+    es.onerror = () => {
+      setStatus('SSE connection lost — reconnecting...');
+      es.close();
+      _reconnectTimer = setTimeout(connectSSE, 3000);
+    };
+    es.onmessage = (event) => {
+      const msg = JSON.parse(event.data);
+      handleEvent(msg);
+    };
+  }
 
-  es.onmessage = (event) => {
-    const msg = JSON.parse(event.data);
-    handleEvent(msg);
-  };
+  connectSSE();
 
   function handleEvent(msg) {
     switch (msg.type) {

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -1,0 +1,80 @@
+"""Unit tests for build_competitor_candidates — pure function, no network calls."""
+import pytest
+from agents.candidates import build_competitor_candidates
+
+
+STRIPE = {
+    "name": "Stripe",
+    "pricing_model": "2.9% + 30¢ per successful card transaction",
+    "market_positioning": "Developer-first payments platform with extensive API coverage",
+    "key_differentiators": ["instant payouts", "global reach", "strong DX"],
+    "confidence_notes": "TechCrunch, 2024-06-01",
+}
+
+STRIPE_WITH_CLAIM = {
+    **STRIPE,
+    "claim": {
+        "schema_version": 2,
+        "entity_key": "organization:stripe",
+        "attribute": "pricing.processing_rate",
+        "value": {"basis_points": 290, "minor_units": 30, "currency": "USD"},
+    },
+}
+
+MINIMAL = {
+    "name": "Acme",
+}
+
+
+def test_returns_tuple():
+    raw_text, candidates = build_competitor_candidates(STRIPE, "techcrunch", "2024-06-01")
+    assert isinstance(raw_text, str)
+    assert isinstance(candidates, list)
+
+
+def test_pricing_candidate_always_present():
+    _, candidates = build_competitor_candidates(STRIPE, "techcrunch", "2024-06-01")
+    kinds = [c["kind"] for c in candidates]
+    assert "domain_fact" in kinds
+    pricing = next(c for c in candidates if c["metadata"]["fact"] == "pricing")
+    assert "Stripe" in pricing["text"]
+    assert "2.9%" in pricing["text"]
+
+
+def test_positioning_and_differentiators_emitted():
+    _, candidates = build_competitor_candidates(STRIPE, "techcrunch", "2024-06-01")
+    facts = {c["metadata"]["fact"] for c in candidates}
+    assert "positioning" in facts
+    assert "differentiators" in facts
+
+
+def test_claim_block_attached_when_present():
+    _, candidates = build_competitor_candidates(STRIPE_WITH_CLAIM, "techcrunch", "2024-06-01")
+    pricing = next(c for c in candidates if c["metadata"]["fact"] == "pricing")
+    assert "claim" in pricing
+    assert pricing["claim"]["attribute"] == "pricing.processing_rate"
+
+
+def test_no_claim_block_without_source_claim():
+    _, candidates = build_competitor_candidates(STRIPE, "techcrunch", "2024-06-01")
+    pricing = next(c for c in candidates if c["metadata"]["fact"] == "pricing")
+    assert "claim" not in pricing
+
+
+def test_minimal_competitor_no_crash():
+    raw_text, candidates = build_competitor_candidates(MINIMAL, "source", "2024-01-01")
+    assert isinstance(candidates, list)
+    assert len(candidates) >= 1  # pricing candidate always emitted
+
+
+def test_source_label_in_metadata():
+    _, candidates = build_competitor_candidates(STRIPE, "bloomberg", "2024-01-01")
+    for c in candidates:
+        assert c["metadata"]["source"] == "bloomberg"
+
+
+def test_raw_text_contains_key_fields():
+    raw_text, _ = build_competitor_candidates(STRIPE, "techcrunch", "2024-06-01")
+    assert "Stripe" in raw_text
+    assert "2.9%" in raw_text
+    assert "techcrunch" in raw_text

--- a/tests/test_memory_diff.py
+++ b/tests/test_memory_diff.py
@@ -1,0 +1,76 @@
+"""Unit tests for the memory diff logic in AsyncStatewaveClient.get_memory_diff."""
+import pytest
+
+
+def _apply_diff(all_memories: list[dict], before_ids: set[str]) -> dict:
+    """Pure extraction of the diff logic from AsyncStatewaveClient.get_memory_diff."""
+    new, superseded, unchanged = [], [], []
+    for mem in all_memories:
+        mem_id = mem.get("id", "")
+        status = mem.get("status", "active")
+        if status == "active":
+            if mem_id not in before_ids:
+                new.append(mem)
+            else:
+                unchanged.append(mem)
+        elif status == "superseded" and mem_id in before_ids:
+            superseded.append(mem)
+    return {"new": new, "superseded": superseded, "unchanged": unchanged}
+
+
+def _mem(id: str, status: str = "active") -> dict:
+    return {"id": id, "status": status, "text": f"memory {id}"}
+
+
+def test_new_memory_detected():
+    before = {"a"}
+    after = [_mem("a"), _mem("b")]
+    diff = _apply_diff(after, before)
+    assert [m["id"] for m in diff["new"]] == ["b"]
+    assert [m["id"] for m in diff["unchanged"]] == ["a"]
+    assert diff["superseded"] == []
+
+
+def test_superseded_memory_detected():
+    before = {"a", "b"}
+    after = [_mem("a"), _mem("b", "superseded")]
+    diff = _apply_diff(after, before)
+    assert [m["id"] for m in diff["superseded"]] == ["b"]
+    assert [m["id"] for m in diff["unchanged"]] == ["a"]
+    assert diff["new"] == []
+
+
+def test_superseded_memory_not_in_before_ignored():
+    # A memory that was already superseded before our snapshot shouldn't surface.
+    before = {"a"}
+    after = [_mem("a"), _mem("x", "superseded")]
+    diff = _apply_diff(after, before)
+    assert diff["superseded"] == []
+    assert diff["new"] == []
+
+
+def test_empty_before_all_new():
+    before: set[str] = set()
+    after = [_mem("a"), _mem("b")]
+    diff = _apply_diff(after, before)
+    assert {m["id"] for m in diff["new"]} == {"a", "b"}
+    assert diff["superseded"] == []
+    assert diff["unchanged"] == []
+
+
+def test_empty_after():
+    before = {"a"}
+    diff = _apply_diff([], before)
+    assert diff == {"new": [], "superseded": [], "unchanged": []}
+
+
+def test_conflict_resolution_scenario():
+    # Simulate: bloomberg committed 'stripe-pricing', then techcrunch superseded it.
+    before = {"stripe-pricing-bloomberg"}
+    after = [
+        _mem("stripe-pricing-bloomberg", "superseded"),
+        _mem("stripe-pricing-techcrunch", "active"),
+    ]
+    diff = _apply_diff(after, before)
+    assert [m["id"] for m in diff["superseded"]] == ["stripe-pricing-bloomberg"]
+    assert [m["id"] for m in diff["new"]] == ["stripe-pricing-techcrunch"]


### PR DESCRIPTION
## Summary

- **Configurable domain**: `SUBJECT_ID`, synthesis prompt, and demo seeding moved to env vars; agents auto-discovered from `sources/*.json` so no Python edits needed to adapt to a new domain
- **`statewave_tools.py`**: drop-in `remember()`, `compile()`, `recall()` helpers -- copy one file into any project to add Statewave memory; README framework examples updated to use it
- **Tests + CI**: 14 unit tests covering `build_competitor_candidates` and memory diff logic; CI now runs `pytest tests/` on every push
- **Startup hardening**: FastAPI lifespan validates `LLM_API_KEY` at boot; structured logging; SSE auto-reconnects instead of asking for a page refresh
- **README**: new Adapting to your domain section, audit trail example output, updated env vars table, updated project structure, all em dashes removed

## Test plan

- [ ] `pytest tests/ -v` passes (14 tests)
- [ ] `python server.py` without `LLM_API_KEY` exits with a clear error
- [ ] Drop a new JSON source into `sources/`, set `DEMO_SEED_BLOOMBERG_STRIPE=false` in `.env`, run pipeline -- new agent appears automatically
- [ ] `from statewave_tools import remember, compile, recall` works in a blank Python file with only `httpx` installed