### PR TITLE
docs(readme): unify hub-and-spoke ecosystem header

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 Three analyst agents ingest conflicting source documents concurrently. Watch Statewave detect the contradiction, supersede the stale fact, and serve the correct answer automatically, with no merge logic written by you.
 
+> **Part of [Statewave](https://github.com/smaramwbc/statewave)** — the open-source memory runtime for AI agents.
+>
+> 📦 [Core runtime](https://github.com/smaramwbc/statewave) · 🐍 [Python SDK](https://github.com/smaramwbc/statewave-py) · 🟦 [TypeScript SDK](https://github.com/smaramwbc/statewave-ts) · 🔌 [Connectors](https://github.com/smaramwbc/statewave-connectors) · 📘 [Docs](https://github.com/smaramwbc/statewave-docs) · 💡 [Examples](https://github.com/smaramwbc/statewave-examples) · 🖥️ [Admin](https://github.com/smaramwbc/statewave-admin) · 🌐 [statewave.ai](https://statewave.ai)
+>
+> 📋 **Issues & feature requests:** [statewave/issues](https://github.com/smaramwbc/statewave/issues) (centralized tracker)
+
 ---
 
 ## Contents


### PR DESCRIPTION
## What

Adds the unified **"Part of Statewave"** ecosystem header to the top of this repo's README — linking the core runtime, Python & TypeScript SDKs, connectors, docs, examples, admin, and statewave.ai, plus a centralized issue-tracker line. Where the repo appears in the nav, its own entry is marked as the active "you are here" item.

## Why

Consistent hub-and-spoke navigation across the public repos: whichever repo a visitor lands on, they get a clear path back to the core project and its siblings.

## Scope

README-only — no code or behavior changes.
